### PR TITLE
Fix eigen version to tag 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Other than that, this repository is the same as the original (https://github.com
 git clone https://github.com/JustusThies/PyMarchingCubes.git
 cd PyMarchingCubes
 git clone https://gitlab.com/libeigen/eigen.git
+cd eigen
+git checkout tags/3.4.0
+cd ..
 python setup.py install
 ```
 


### PR DESCRIPTION
Currently the README instructs to install the unstable master branch of `eigen` which breaks things for me. Installing the latest tagged version fixed it